### PR TITLE
GitHub Actions で CI を動かします

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+# 複数の Node.js でテスト, ビルド, lint を行い、動作することを確認します
+name: test_and_build
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          # https://github.com/nodejs/Release#release-schedule
+          - 16.x # メンテナンス (2023/09/11 まで)
+          - 18.x # LTS
+          - 19.x # 現在
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: インストール
+        run: npm install
+
+      - name: ビルド
+        run: npm run build
+
+      - name: lint
+        run: npm run lint


### PR DESCRIPTION
以下が正常に実行できるか GitHub Actions で CI を走らせ、チェックします

- npm install
- npm run lint
- npm run build

# モチベーション

プロジェクトにパッチを送ろうとするときに、「もしかしたら私の変更を加えたことでビルドが通らなくなってしまわないか」「使っているバージョンによって動作が異なってしまわないか」などが不安になることがあります。

CI を追加することで、複数の Node.js のバージョンで build / lint が走ります。それによって複数のバージョンで互換性があることが保証されます。

※ 本来はユニットテストもあれば加えようと思ったのですが、ないのでそのままにしています

現状ポピュラーであろう LTS 系の 16, 18 と、最新のバージョンである 19 をテスト対象にしています。

# 動作の例

[こちらは fork 先で実際に動いている例](https://github.com/yuitest/lunchtote-frontend/pull/1) です。

以下のスクリーンショットのように、プルリクエストを作るたびに複数の Node.js のバージョンで install / build / lint が走ります。

<img width="919" alt="Screenshot 2022-12-21 at 9 45 19" src="https://user-images.githubusercontent.com/726855/208794238-97a103e6-d1ea-468d-b771-8b32b3cbad82.png">
<img width="1349" alt="Screenshot 2022-12-21 at 9 45 55" src="https://user-images.githubusercontent.com/726855/208794289-2c1b926d-5368-47a0-abaa-f8f9140053e7.png">
